### PR TITLE
Fix build again (babel)

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-regenerator": "6.16.1",
     "babel-polyfill": "^6.3.14",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-es2015": "6.16.0",
     "babel-preset-es2015-rollup": "^1.1.1",
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.1.1",


### PR DESCRIPTION
Fixing 'babel-preset-es2015' to exactly version 6.16.0 allows npm to
satisfy our request to ensure babel-plugin-transform-regenerator stays
exactly at version 6.16.1 - with bang up-to-date babel-preset-es2015 the
module was getting its own private copy of
babel-plugin-transform-regenerator to satisfy its listed dependencies,
and this was breaking the build.

Left a comment with repro instructions for babel upstream at
https://github.com/babel/babel/issues/4982#issuecomment-281733555